### PR TITLE
Update Extension Pack to v2.2.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,14 @@ This is Bad Company. A VSCode Extension Pack for me.
 
 ## [Unreleased]
 
+## [2.2.0] 2026/02/25
+### Added
+- `GitHub.vscode-github-actions` (Added by Jules)
+- `meta.pyrefly` (Added by Jules)
+
+### Removed
+- `ms-vscode.vscode-typescript-next` (Removed by Jules)
+
 ## [2.1.5] 2026/02/25
 ### Changed
 - `AGENTS.md` に CHANGELOG の実行主体記載ルールを追加 `(Updated by Codex)`

--- a/README.md
+++ b/README.md
@@ -20,12 +20,12 @@ This extension pack includes the following extensions:
   - [Catppuccin Perfect Icons](https://marketplace.visualstudio.com/items?itemName=thang-nm.catppuccin-perfect-icons)
   - [Andromeda](https://marketplace.visualstudio.com/items?itemName=eliverlara.andromeda)
 - **TypeScript/JavaScript:**
-  - [JavaScript and TypeScript Nightly](https://marketplace.visualstudio.com/items?itemName=ms-vscode.vscode-typescript-next)
   - [Bun for Visual Studio Code](https://marketplace.visualstudio.com/items?itemName=oven.bun-vscode)
   - [Deno](https://marketplace.visualstudio.com/items?itemName=denoland.vscode-deno)
   - [Biome](https://marketplace.visualstudio.com/items?itemName=biomejs.biome)
   - [Prettier](https://marketplace.visualstudio.com/items?itemName=esbenp.prettier-vscode)
 - **Python:**
+  - [Pyrefly](https://marketplace.visualstudio.com/items?itemName=meta.pyrefly)
   - [Python](https://marketplace.visualstudio.com/items?itemName=ms-python.python)
   - [Pylance](https://marketplace.visualstudio.com/items?itemName=ms-python.vscode-pylance)
   - [Python Debugger](https://marketplace.visualstudio.com/items?itemName=ms-python.debugpy)
@@ -44,6 +44,7 @@ This extension pack includes the following extensions:
   - [EditorConfig](https://marketplace.visualstudio.com/items?itemName=editorconfig.editorconfig)
 - **DevOps & Infrastructure:**
   - [Tailscale](https://marketplace.visualstudio.com/items?itemName=tailscale.vscode-tailscale)
+  - [GitHub Actions](https://marketplace.visualstudio.com/items?itemName=GitHub.vscode-github-actions)
 - **Review:**
   - [MDX](https://marketplace.visualstudio.com/items?itemName=unifiedjs.vscode-mdx)
 

--- a/package.json
+++ b/package.json
@@ -2,7 +2,7 @@
   "name": "bad-company",
   "displayName": "Bad Company",
   "description": "Wonderful extensions created by God!",
-  "version": "2.1.5",
+  "version": "2.2.0",
   "repository": {
     "type": "git",
     "url": "https://github.com/BuntinJP/bad-company.git"
@@ -37,7 +37,6 @@
     "catppuccin.catppuccin-vsc",
     "thang-nm.catppuccin-perfect-icons",
     "eliverlara.andromeda",
-    "ms-vscode.vscode-typescript-next",
     "oven.bun-vscode",
     "denoland.vscode-deno",
     "biomejs.biome",
@@ -54,7 +53,9 @@
     "tomoki1207.pdf",
     "editorconfig.editorconfig",
     "unifiedjs.vscode-mdx",
-    "tailscale.vscode-tailscale"
+    "tailscale.vscode-tailscale",
+    "GitHub.vscode-github-actions",
+    "meta.pyrefly"
   ],
   "devDependencies": {
     "vsce": "^2.15.0"


### PR DESCRIPTION
Added GitHub Actions and Pyrefly extensions, removed TypeScript Nightly, and updated version to 2.2.0.

---
*PR created automatically by Jules for task [14984608816023044075](https://jules.google.com/task/14984608816023044075) started by @BuntinJP*