### PR TITLE
Add Gemini CLI Companion to Extension Pack

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,9 +4,11 @@ This is Bad Company. A VSCode Extension Pack for me.
 
 ## [Unreleased]
 
-## [2.3.0] 2026/02/25
+## [2.3.0] 2026/03/22
 ### Added
 - `google.gemini-cli-vscode-ide-companion` (Added by Jules)
+- `mechatroner.rainbow-csv` (Added by Jules)
+- `tamasfe.even-better-toml` (Added by Jules)
 
 ## [2.2.0] 2026/02/25
 ### Added

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,10 @@ This is Bad Company. A VSCode Extension Pack for me.
 
 ## [Unreleased]
 
+## [2.3.0] 2026/02/25
+### Added
+- `google.gemini-cli-vscode-ide-companion` (Added by Jules)
+
 ## [2.2.0] 2026/02/25
 ### Added
 - `GitHub.vscode-github-actions` (Added by Jules)

--- a/README.md
+++ b/README.md
@@ -15,6 +15,7 @@ This extension pack includes the following extensions:
   - [Gemini Code Assist](https://marketplace.visualstudio.com/items?itemName=google.geminicodeassist)
   - [Claude Code for VS Code](https://marketplace.visualstudio.com/items?itemName=anthropic.claude-code)
   - [Cline](https://marketplace.visualstudio.com/items?itemName=saoudrizwan.claude-dev)
+  - [Gemini CLI Companion](https://marketplace.visualstudio.com/items?itemName=google.gemini-cli-vscode-ide-companion)
 - **Themes:**
   - [Catppuccin for VSCode](https://marketplace.visualstudio.com/items?itemName=catppuccin.catppuccin-vsc)
   - [Catppuccin Perfect Icons](https://marketplace.visualstudio.com/items?itemName=thang-nm.catppuccin-perfect-icons)

--- a/README.md
+++ b/README.md
@@ -34,6 +34,7 @@ This extension pack includes the following extensions:
 - **Other Languages:**
   - [XML](https://marketplace.visualstudio.com/items?itemName=redhat.vscode-xml)
   - [YAML](https://marketplace.visualstudio.com/items?itemName=redhat.vscode-yaml)
+  - [Even Better TOML](https://marketplace.visualstudio.com/items?itemName=tamasfe.even-better-toml)
 - **Shell:**
   - [shfmt](https://marketplace.visualstudio.com/items?itemName=mkhl.shfmt)
 - **Git:**
@@ -41,6 +42,7 @@ This extension pack includes the following extensions:
 - **Utilities:**
   - [zenkaku](https://marketplace.visualstudio.com/items?itemName=mosapride.zenkaku)
   - [vscode-pdf](https://marketplace.visualstudio.com/items?itemName=tomoki1207.pdf)
+  - [Rainbow CSV](https://marketplace.visualstudio.com/items?itemName=mechatroner.rainbow-csv)
 - **Configuration:**
   - [EditorConfig](https://marketplace.visualstudio.com/items?itemName=editorconfig.editorconfig)
 - **DevOps & Infrastructure:**

--- a/package.json
+++ b/package.json
@@ -2,7 +2,7 @@
   "name": "bad-company",
   "displayName": "Bad Company",
   "description": "Wonderful extensions created by God!",
-  "version": "2.2.0",
+  "version": "2.3.0",
   "repository": {
     "type": "git",
     "url": "https://github.com/BuntinJP/bad-company.git"
@@ -55,7 +55,8 @@
     "unifiedjs.vscode-mdx",
     "tailscale.vscode-tailscale",
     "GitHub.vscode-github-actions",
-    "meta.pyrefly"
+    "meta.pyrefly",
+    "google.gemini-cli-vscode-ide-companion"
   ],
   "devDependencies": {
     "vsce": "^2.15.0"

--- a/package.json
+++ b/package.json
@@ -56,7 +56,9 @@
     "tailscale.vscode-tailscale",
     "GitHub.vscode-github-actions",
     "meta.pyrefly",
-    "google.gemini-cli-vscode-ide-companion"
+    "google.gemini-cli-vscode-ide-companion",
+    "mechatroner.rainbow-csv",
+    "tamasfe.even-better-toml"
   ],
   "devDependencies": {
     "vsce": "^2.15.0"


### PR DESCRIPTION
Added the `google.gemini-cli-vscode-ide-companion` extension to the Bad Company extension pack. This includes updating `package.json`, `README.md`, and `CHANGELOG.md`, and incrementing the project version to 2.3.0. All changes follow the guidelines in `AGENTS.md`.

Fixes #4

---
*PR created automatically by Jules for task [15191193826566108555](https://jules.google.com/task/15191193826566108555) started by @BuntinJP*